### PR TITLE
Tighten audio dock layout and indicator states

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3080,6 +3080,7 @@ body.dark .global_shapes {
 
 /*=============== AUDIO PLAYER ===============*/
 
+
 .audio-dock {
     position: fixed;
     bottom: 28px;
@@ -3087,10 +3088,11 @@ body.dark .global_shapes {
     z-index: 9999;
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
     opacity: 0;
     visibility: hidden;
     --dock-shift-x: 0;
+    --toggle-visible: 30px;
     transform: translate(var(--dock-shift-x), 18px);
     pointer-events: none;
     transition: opacity 0.38s ease, transform 0.5s cubic-bezier(0.22, 0.61, 0.36, 1), visibility 0.38s ease;
@@ -3106,7 +3108,7 @@ body.dark .global_shapes {
 
 .audio-player-container {
     position: relative;
-    width: min(280px, calc(100% - 86px));
+    width: min(260px, calc(100% - 78px));
     background: linear-gradient(150deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.08));
     border-radius: 18px;
     box-shadow: 0 16px 44px rgba(0, 0, 0, 0.22);
@@ -3135,15 +3137,15 @@ body.dark .audio-player-container {
 }
 
 .audio-dock.is-collapsed .audio-player-container {
-    transform: translateX(-14px);
+    transform: translateX(-24px);
     opacity: 0;
     pointer-events: none;
     box-shadow: 0 8px 26px rgba(0, 0, 0, 0.24);
 }
 
 .audio-toggle {
-    width: 40px;
-    height: 110px;
+    width: 30px;
+    height: 118px;
     display: grid;
     place-items: center;
     border: none;
@@ -3155,7 +3157,7 @@ body.dark .audio-player-container {
     box-shadow: 0 14px 32px rgba(0, 0, 0, 0.24);
     backdrop-filter: blur(12px);
     border: 1px solid rgba(255, 255, 255, 0.6);
-    transition: transform 0.38s ease, box-shadow 0.32s ease, opacity 0.25s ease, background 0.35s ease;
+    transition: transform 0.38s ease, box-shadow 0.32s ease, opacity 0.25s ease, background 0.35s ease, right 0.38s ease;
 }
 
 body.dark .audio-toggle {
@@ -3165,9 +3167,10 @@ body.dark .audio-toggle {
     border-color: rgba(255, 255, 255, 0.14);
 }
 
+
 .audio-toggle svg {
-    width: 18px;
-    height: 18px;
+    width: 17px;
+    height: 17px;
     fill: currentColor;
     opacity: 0.9;
     transition: transform 0.35s ease, opacity 0.25s ease;
@@ -3182,12 +3185,18 @@ body.dark .audio-toggle {
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.32);
 }
 
-.audio-dock.is-collapsed .audio-toggle {
-    transform: translateX(0);
+.audio-toggle::before {
+    content: "";
+    position: absolute;
+    inset: 4px;
+    border-radius: inherit;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    opacity: 0.5;
+    pointer-events: none;
 }
 
 .audio-dock.is-collapsed {
-    --dock-shift-x: calc(-100% + 40px);
+    --dock-shift-x: calc(-100% + var(--toggle-visible));
 }
 
 .audio-player {
@@ -3319,13 +3328,13 @@ body.dark .audio-cover__art {
     display: flex;
     flex-direction: column;
     gap: 10px;
-    padding-top: 4px;
+    padding-top: 2px;
 }
 
 .audio-progress__rail {
     position: relative;
     width: 100%;
-    height: 10px;
+    height: 12px;
     border-radius: 999px;
     background: rgba(0, 0, 0, 0.08);
     overflow: hidden;
@@ -3355,17 +3364,17 @@ body.dark .audio-progress__rail {
     left: 0;
     top: 50%;
     transform: translateY(-50%);
-    height: 28px;
+    height: 32px;
     cursor: pointer;
 }
 
 #audioSeek::-webkit-slider-runnable-track {
-    height: 10px;
+    height: 12px;
     background: transparent;
 }
 
 #audioSeek::-moz-range-track {
-    height: 10px;
+    height: 12px;
     background: transparent;
 }
 
@@ -3378,7 +3387,7 @@ body.dark .audio-progress__rail {
     background: #fff;
     border: 3px solid #63a5ff;
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
-    margin-top: -4px;
+    margin-top: -6px;
 }
 
 #audioSeek::-moz-range-thumb {
@@ -3388,7 +3397,7 @@ body.dark .audio-progress__rail {
     background: #fff;
     border: 3px solid #63a5ff;
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
-    transform: translateY(-2px);
+    transform: translateY(-4px);
 }
 
 .audio-times {
@@ -3507,7 +3516,7 @@ body.dark .audio-player__btn--ghost {
     }
 
     .audio-toggle {
-        height: 96px;
-        width: 36px;
+        height: 100px;
+        width: 28px;
     }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3079,97 +3079,426 @@ body.dark .global_shapes {
 }
 
 /*=============== AUDIO PLAYER ===============*/
-.audio-player-container {
+.audio-dock {
     position: fixed;
-    bottom: 30px;
-    left: 35px;
-    z-index: 9999; /* Tăng z-index cao nhất để không bị che */
-    width: 280px;  /* Tăng chiều rộng một chút cho thoải mái */
-    background: #1a1f3a; /* Màu nền tối (khớp với ảnh) hoặc dùng var(--container-color) */
-    border-radius: 12px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    padding: 12px 16px;
+    bottom: 28px;
+    left: 20px;
+    z-index: 9999;
     display: flex;
     align-items: center;
-    gap: 10px;
-    cursor: grab;
-    border: 1px solid rgba(255, 255, 255, 0.1); /* Viền mờ cho đẹp */
-    transition: transform 0.1s;
+    gap: 12px;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(18px);
+    pointer-events: none;
+    transition: opacity 0.38s ease, transform 0.5s cubic-bezier(0.22, 0.61, 0.36, 1), visibility 0.38s ease;
 }
 
-.audio-player-container:active {
-    cursor: grabbing;
+.audio-dock.is-visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    pointer-events: auto;
 }
 
-/* Mobile responsive */
-@media screen and (max-width: 767px) {
-    .audio-player-container {
-        width: 220px;
-        bottom: 80px; /* Nâng cao lên tránh bị menu che */
-        left: 15px;
-    }
+.audio-player-container {
+    position: relative;
+    width: min(300px, calc(100% - 96px));
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.08));
+    border-radius: 18px;
+    box-shadow: 0 16px 44px rgba(0, 0, 0, 0.22);
+    padding: 12px 14px 14px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(18px);
+    overflow: hidden;
+    transition: transform 0.58s cubic-bezier(0.18, 0.68, 0.32, 1.03), opacity 0.45s ease, box-shadow 0.3s ease;
+}
+
+.audio-player-container::after {
+    content: "";
+    position: absolute;
+    inset: 1px;
+    border-radius: inherit;
+    background: radial-gradient(circle at 22% 28%, rgba(255, 255, 255, 0.3), transparent 42%),
+        radial-gradient(circle at 80% 8%, rgba(255, 255, 255, 0.14), transparent 45%);
+    pointer-events: none;
+    opacity: 0.85;
+}
+
+body.dark .audio-player-container {
+    background: linear-gradient(155deg, rgba(18, 23, 38, 0.94), rgba(11, 16, 28, 0.92));
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 22px 60px rgba(0, 0, 0, 0.48);
+}
+
+.audio-dock.is-collapsed .audio-player-container {
+    transform: translateX(calc(-100% - 24px));
+    opacity: 0;
+    pointer-events: none;
+    box-shadow: 0 8px 26px rgba(0, 0, 0, 0.24);
+}
+
+.audio-toggle {
+    width: 46px;
+    height: 120px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.32));
+    border-radius: 999px;
+    cursor: pointer;
+    padding: 0;
+    color: #273248;
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.24);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    transition: transform 0.38s ease, box-shadow 0.32s ease, opacity 0.25s ease, background 0.35s ease;
+}
+
+body.dark .audio-toggle {
+    color: #e5edff;
+    background: linear-gradient(150deg, rgba(58, 70, 102, 0.95), rgba(32, 40, 64, 0.94));
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.42);
+    border-color: rgba(255, 255, 255, 0.14);
+}
+
+.audio-toggle svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+    opacity: 0.9;
+    transition: transform 0.35s ease, opacity 0.25s ease;
+}
+
+.audio-dock.is-collapsed .audio-toggle svg {
+    transform: rotate(180deg);
+}
+
+.audio-toggle:hover {
+    opacity: 1;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.32);
+}
+
+.audio-dock.is-collapsed .audio-toggle {
+    transform: translateX(4px);
 }
 
 .audio-player {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    z-index: 1;
+}
+
+.audio-player__top {
     display: flex;
     align-items: center;
     justify-content: space-between;
+}
+
+.audio-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    color: rgba(0, 0, 0, 0.55);
+    font-size: 0.8rem;
+    letter-spacing: 0.02em;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+body.dark .audio-chip {
+    color: #e8edf7;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.audio-chip__dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #f472b6, #60a5fa);
+    box-shadow: 0 0 0 6px rgba(96, 165, 250, 0.16);
+}
+
+.audio-icon-badge {
+    width: 36px;
+    height: 36px;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 12px;
+    color: rgba(0, 0, 0, 0.55);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+body.dark .audio-icon-badge {
+    color: #d4dcf5;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.audio-player__meta {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 10px;
+    align-items: center;
+}
+
+.audio-cover {
+    position: relative;
+    width: 72px;
+    height: 72px;
+    display: grid;
+    place-items: center;
+}
+
+.audio-cover__art {
+    position: relative;
     width: 100%;
-}
-
-.audio-player__info {
-    flex-grow: 1;
+    height: 100%;
+    border-radius: 22px;
     overflow: hidden;
-    margin-right: 8px;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.08));
+    color: rgba(0, 0, 0, 0.6);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.52), 0 14px 26px rgba(0, 0, 0, 0.12);
 }
 
-.audio-player__track-name {
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: #fff; /* Chữ trắng */
+body.dark .audio-cover__art {
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04));
+    color: #dce3f7;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 22px rgba(0, 0, 0, 0.45);
+}
+
+.audio-cover__glow {
+    position: absolute;
+    inset: -20%;
+    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.25), transparent 45%),
+        radial-gradient(circle at 80% 20%, rgba(120, 166, 255, 0.18), transparent 45%),
+        radial-gradient(circle at 50% 70%, rgba(244, 114, 182, 0.16), transparent 45%);
+    transform: scale(1.05);
+    filter: blur(1px);
+}
+
+.audio-cover__art i {
+    font-size: 1.6rem;
+    position: relative;
+    z-index: 1;
+}
+
+.audio-track__title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--title-color);
+    margin: 0 0 4px;
+    line-height: 1.25;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.audio-track__subtitle {
     margin: 0;
+    color: var(--text-color);
+    opacity: 0.8;
+    font-size: 0.95rem;
+}
+
+.audio-progress {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-top: 4px;
+}
+
+.audio-progress__rail {
+    position: relative;
+    width: 100%;
+    height: 10px;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+    filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.12));
+}
+
+body.dark .audio-progress__rail {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.audio-progress__bar {
+    position: absolute;
+    inset: 0;
+    width: 0%;
+    background: linear-gradient(100deg, #63a5ff, #8f7bff, #f472b6);
+    border-radius: inherit;
+    box-shadow: 0 6px 16px rgba(99, 165, 255, 0.3);
+}
+
+#audioSeek {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    margin: 0;
+    background: transparent;
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 34px;
+    cursor: pointer;
+}
+
+#audioSeek::-webkit-slider-runnable-track {
+    height: 10px;
+    background: transparent;
+}
+
+#audioSeek::-moz-range-track {
+    height: 10px;
+    background: transparent;
+}
+
+#audioSeek::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #fff;
+    border: 3px solid #63a5ff;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
+}
+
+#audioSeek::-moz-range-thumb {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #fff;
+    border: 3px solid #63a5ff;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
+}
+
+.audio-times {
+    display: flex;
+    justify-content: space-between;
+    color: var(--text-color);
+    font-weight: 600;
+    font-size: 0.9rem;
+    opacity: 0.8;
 }
 
 .audio-player__controls {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 10px;
     align-items: center;
-    gap: 8px; /* Khoảng cách giữa các nút */
+    margin-top: 4px;
 }
 
-/* Sửa lỗi viền trắng nút bấm */
 .audio-player__btn {
-    background: transparent !important;
-    border: none !important;
-    outline: none !important;
-    box-shadow: none !important;
-    color: #a8b2d1; /* Màu icon mặc định */
+    background: rgba(255, 255, 255, 0.14);
+    border: 1px solid rgba(255, 255, 255, 0.32);
+    outline: none;
+    color: var(--title-color);
     cursor: pointer;
     font-size: 1rem;
     padding: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: all 0.2s ease;
-    width: 30px;
-    height: 30px;
-    border-radius: 50%;
+    transition: transform 0.2s ease, box-shadow 0.25s ease, background 0.25s ease, color 0.2s ease;
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12);
+}
+
+body.dark .audio-player__btn {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.08);
+    color: #e9edf7;
+    box-shadow: 0 12px 22px rgba(0, 0, 0, 0.35);
 }
 
 .audio-player__btn:hover {
-    color: #fff;
-    background: rgba(255, 255, 255, 0.1) !important; /* Hiệu ứng hover nhẹ */
+    transform: translateY(-1px);
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.2);
 }
 
-.audio-player__btn--play {
-    font-size: 1.4rem; /* Icon Play to hơn */
+.audio-player__btn--primary {
+    background: linear-gradient(120deg, #60a5fa, #a78bfa);
     color: #fff;
-    width: 36px;
-    height: 36px;
+    border-color: transparent;
+    font-size: 1.2rem;
+    box-shadow: 0 16px 30px rgba(96, 165, 250, 0.4);
 }
 
-.audio-player__btn--loop.active {
-    color: #38bdf8 !important; /* Màu xanh khi bật Loop */
+.audio-player__btn--ghost {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text-color);
+}
+
+body.dark .audio-player__btn--ghost {
+    color: #cdd6ea;
+}
+
+.audio-player__btn--ghost.active {
+    color: #60a5fa;
+    box-shadow: 0 12px 22px rgba(96, 165, 250, 0.35);
+}
+
+.audio-player__btn--ghost.is-on {
+    color: #22c55e;
+    background: rgba(34, 197, 94, 0.12);
+    border-color: rgba(34, 197, 94, 0.45);
+    box-shadow: 0 12px 20px rgba(34, 197, 94, 0.28);
+}
+
+#heartToggleBtn.is-on {
+    color: #f43f5e;
+    background: rgba(244, 63, 94, 0.16);
+    border-color: rgba(244, 63, 94, 0.46);
+    box-shadow: 0 12px 20px rgba(244, 63, 94, 0.26);
+}
+
+#loopToggleBtn.is-on {
+    color: #22c55e;
+    background: rgba(34, 197, 94, 0.12);
+    border-color: rgba(34, 197, 94, 0.45);
+}
+
+/* Mobile responsive */
+@media screen and (max-width: 767px) {
+    .audio-dock {
+        left: 12px;
+        bottom: 18px;
+    }
+
+    .audio-player-container {
+        width: calc(100% - 92px);
+        padding: 12px 12px 14px;
+    }
+
+    .audio-cover {
+        width: 68px;
+        height: 68px;
+    }
+
+    .audio-player__controls {
+        gap: 8px;
+    }
+
+    .audio-player__btn {
+        width: 42px;
+        height: 42px;
+    }
+
+    .audio-toggle {
+        height: 100px;
+        width: 44px;
+    }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3088,11 +3088,13 @@ body.dark .global_shapes {
     z-index: 9999;
     display: flex;
     align-items: center;
-    gap: 8px;
+    --dock-gap: 8px;
+    --toggle-width: 28px;
+    gap: var(--dock-gap);
     opacity: 0;
     visibility: hidden;
     --dock-shift-x: 0;
-    --toggle-visible: 30px;
+    --toggle-visible: calc(var(--toggle-width) + var(--dock-gap) + 6px);
     transform: translate(var(--dock-shift-x), 18px);
     pointer-events: none;
     transition: opacity 0.38s ease, transform 0.5s cubic-bezier(0.22, 0.61, 0.36, 1), visibility 0.38s ease;
@@ -3144,7 +3146,7 @@ body.dark .audio-player-container {
 }
 
 .audio-toggle {
-    width: 30px;
+    width: var(--toggle-width);
     height: 118px;
     display: grid;
     place-items: center;
@@ -3387,7 +3389,7 @@ body.dark .audio-progress__rail {
     background: #fff;
     border: 3px solid #63a5ff;
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
-    margin-top: -6px;
+    margin-top: -3px;
 }
 
 #audioSeek::-moz-range-thumb {
@@ -3397,7 +3399,7 @@ body.dark .audio-progress__rail {
     background: #fff;
     border: 3px solid #63a5ff;
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
-    transform: translateY(-4px);
+    transform: translateY(-3px);
 }
 
 .audio-times {
@@ -3494,6 +3496,9 @@ body.dark .audio-player__btn--ghost {
     .audio-dock {
         left: 12px;
         bottom: 18px;
+        --dock-gap: 6px;
+        --toggle-width: 26px;
+        --toggle-visible: calc(var(--toggle-width) + var(--dock-gap) + 6px);
     }
 
     .audio-player-container {
@@ -3516,7 +3521,6 @@ body.dark .audio-player__btn--ghost {
     }
 
     .audio-toggle {
-        height: 100px;
-        width: 28px;
+        height: 104px;
     }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3089,12 +3089,14 @@ body.dark .global_shapes {
     display: flex;
     align-items: center;
     --dock-gap: 8px;
+    --player-width: min(260px, calc(100% - 78px));
     --toggle-width: 28px;
+    --toggle-outset: 12px;
     gap: var(--dock-gap);
     opacity: 0;
     visibility: hidden;
     --dock-shift-x: 0;
-    --toggle-visible: calc(var(--toggle-width) + var(--dock-gap) + 6px);
+    --toggle-visible: calc(var(--toggle-width) + var(--toggle-outset));
     transform: translate(var(--dock-shift-x), 18px);
     pointer-events: none;
     transition: opacity 0.38s ease, transform 0.5s cubic-bezier(0.22, 0.61, 0.36, 1), visibility 0.38s ease;
@@ -3110,7 +3112,7 @@ body.dark .global_shapes {
 
 .audio-player-container {
     position: relative;
-    width: min(260px, calc(100% - 78px));
+    width: var(--player-width);
     background: linear-gradient(150deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.08));
     border-radius: 18px;
     box-shadow: 0 16px 44px rgba(0, 0, 0, 0.22);
@@ -3198,7 +3200,7 @@ body.dark .audio-toggle {
 }
 
 .audio-dock.is-collapsed {
-    --dock-shift-x: calc(-100% + var(--toggle-visible));
+    --dock-shift-x: calc(-1 * var(--player-width) - var(--dock-gap) + var(--toggle-visible));
 }
 
 .audio-player {
@@ -3328,11 +3330,12 @@ body.dark .audio-cover__art {
 .audio-progress {
     --progress-rail-height: 12px;
     --progress-thumb-size: 18px;
+    --progress-offset: 2px;
     position: relative;
     display: flex;
     flex-direction: column;
     gap: 10px;
-    padding-top: 2px;
+    padding-top: 6px;
 }
 
 .audio-progress__rail {
@@ -3343,6 +3346,7 @@ body.dark .audio-cover__art {
     background: rgba(0, 0, 0, 0.08);
     overflow: hidden;
     filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.12));
+    transform: translateY(var(--progress-offset));
 }
 
 body.dark .audio-progress__rail {
@@ -3366,7 +3370,7 @@ body.dark .audio-progress__rail {
     background: transparent;
     position: absolute;
     left: 0;
-    top: 50%;
+    top: calc(50% + var(--progress-offset));
     transform: translateY(-50%);
     height: 32px;
     cursor: pointer;
@@ -3501,12 +3505,14 @@ body.dark .audio-player__btn--ghost {
         left: 12px;
         bottom: 18px;
         --dock-gap: 6px;
-        --toggle-width: 26px;
-        --toggle-visible: calc(var(--toggle-width) + var(--dock-gap) + 6px);
+        --player-width: calc(100% - 92px);
+        --toggle-width: 25px;
+        --toggle-outset: 10px;
+        --toggle-visible: calc(var(--toggle-width) + var(--toggle-outset));
     }
 
     .audio-player-container {
-        width: calc(100% - 92px);
+        width: var(--player-width);
         padding: 12px 12px 14px;
     }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3326,6 +3326,8 @@ body.dark .audio-cover__art {
 }
 
 .audio-progress {
+    --progress-rail-height: 12px;
+    --progress-thumb-size: 18px;
     position: relative;
     display: flex;
     flex-direction: column;
@@ -3336,7 +3338,7 @@ body.dark .audio-cover__art {
 .audio-progress__rail {
     position: relative;
     width: 100%;
-    height: 12px;
+    height: var(--progress-rail-height);
     border-radius: 999px;
     background: rgba(0, 0, 0, 0.08);
     overflow: hidden;
@@ -3368,38 +3370,40 @@ body.dark .audio-progress__rail {
     transform: translateY(-50%);
     height: 32px;
     cursor: pointer;
+    z-index: 2;
+    touch-action: pan-y;
 }
 
 #audioSeek::-webkit-slider-runnable-track {
-    height: 12px;
+    height: var(--progress-rail-height);
     background: transparent;
 }
 
 #audioSeek::-moz-range-track {
-    height: 12px;
+    height: var(--progress-rail-height);
     background: transparent;
 }
 
 #audioSeek::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 18px;
-    height: 18px;
+    width: var(--progress-thumb-size);
+    height: var(--progress-thumb-size);
     border-radius: 50%;
     background: #fff;
     border: 3px solid #63a5ff;
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
-    margin-top: -3px;
+    margin-top: calc((var(--progress-thumb-size) - var(--progress-rail-height)) / -2);
 }
 
 #audioSeek::-moz-range-thumb {
-    width: 18px;
-    height: 18px;
+    width: var(--progress-thumb-size);
+    height: var(--progress-thumb-size);
     border-radius: 50%;
     background: #fff;
     border: 3px solid #63a5ff;
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
-    transform: translateY(-3px);
+    transform: translateY(calc((var(--progress-rail-height) - var(--progress-thumb-size)) / 2));
 }
 
 .audio-times {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3079,6 +3079,7 @@ body.dark .global_shapes {
 }
 
 /*=============== AUDIO PLAYER ===============*/
+
 .audio-dock {
     position: fixed;
     bottom: 28px;
@@ -3086,10 +3087,11 @@ body.dark .global_shapes {
     z-index: 9999;
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 10px;
     opacity: 0;
     visibility: hidden;
-    transform: translateY(18px);
+    --dock-shift-x: 0;
+    transform: translate(var(--dock-shift-x), 18px);
     pointer-events: none;
     transition: opacity 0.38s ease, transform 0.5s cubic-bezier(0.22, 0.61, 0.36, 1), visibility 0.38s ease;
 }
@@ -3097,13 +3099,14 @@ body.dark .global_shapes {
 .audio-dock.is-visible {
     opacity: 1;
     visibility: visible;
-    transform: translateY(0);
+    transform: translate(var(--dock-shift-x), 0);
     pointer-events: auto;
 }
 
+
 .audio-player-container {
     position: relative;
-    width: min(300px, calc(100% - 96px));
+    width: min(280px, calc(100% - 86px));
     background: linear-gradient(150deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.08));
     border-radius: 18px;
     box-shadow: 0 16px 44px rgba(0, 0, 0, 0.22);
@@ -3132,15 +3135,15 @@ body.dark .audio-player-container {
 }
 
 .audio-dock.is-collapsed .audio-player-container {
-    transform: translateX(calc(-100% - 24px));
+    transform: translateX(-14px);
     opacity: 0;
     pointer-events: none;
     box-shadow: 0 8px 26px rgba(0, 0, 0, 0.24);
 }
 
 .audio-toggle {
-    width: 46px;
-    height: 120px;
+    width: 40px;
+    height: 110px;
     display: grid;
     place-items: center;
     border: none;
@@ -3180,7 +3183,11 @@ body.dark .audio-toggle {
 }
 
 .audio-dock.is-collapsed .audio-toggle {
-    transform: translateX(4px);
+    transform: translateX(0);
+}
+
+.audio-dock.is-collapsed {
+    --dock-shift-x: calc(-100% + 40px);
 }
 
 .audio-player {
@@ -3348,7 +3355,7 @@ body.dark .audio-progress__rail {
     left: 0;
     top: 50%;
     transform: translateY(-50%);
-    height: 34px;
+    height: 28px;
     cursor: pointer;
 }
 
@@ -3371,6 +3378,7 @@ body.dark .audio-progress__rail {
     background: #fff;
     border: 3px solid #63a5ff;
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
+    margin-top: -4px;
 }
 
 #audioSeek::-moz-range-thumb {
@@ -3380,6 +3388,7 @@ body.dark .audio-progress__rail {
     background: #fff;
     border: 3px solid #63a5ff;
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
+    transform: translateY(-2px);
 }
 
 .audio-times {
@@ -3498,7 +3507,7 @@ body.dark .audio-player__btn--ghost {
     }
 
     .audio-toggle {
-        height: 100px;
-        width: 44px;
+        height: 96px;
+        width: 36px;
     }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -17,6 +17,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Preloader animation
   function preloader() {
+    const audioDock = document.getElementById("audioDock");
+    const audioContainer = document.getElementById("audioPlayerContainer");
     var tl = anime.timeline({});
     tl.add({ targets: ".loader", duration: 300, opacity: 1, easing: "easeInOutQuart", })
     .add({ targets: ".preloader__progress span", duration: 500, width: "100%", easing: "easeInOutQuart", }, "-=200")
@@ -24,6 +26,11 @@ document.addEventListener("DOMContentLoaded", () => {
       complete: function () {
         document.getElementById("loader").classList.add("hide");
         document.getElementById("home").style.display = "block";
+        if (audioDock) {
+          audioDock.classList.add("is-visible");
+        } else if (audioContainer) {
+          audioContainer.classList.add("is-visible");
+        }
         if (typeof initAnimations === "function") {
           initAnimations();
         }
@@ -1333,13 +1340,21 @@ sr.reveal('.card.about-card[data-reveal="right"]', {
    FIXED AUDIO PLAYER LOGIC
    ========================================== */
 document.addEventListener("DOMContentLoaded", function() {
+    const audioDock = document.getElementById("audioDock");
     const playerContainer = document.getElementById("audioPlayerContainer");
     const audio = document.getElementById("mainAudio");
     const playPauseBtn = document.getElementById("playPauseBtn");
     const prevBtn = document.getElementById("prevBtn");
     const nextBtn = document.getElementById("nextBtn");
     const trackNameElement = document.getElementById("trackName");
+    const trackSubtitleElement = document.getElementById("trackSubtitle");
     const loopToggleBtn = document.getElementById("loopToggleBtn");
+    const audioToggle = document.getElementById("audioToggle");
+    const heartToggleBtn = document.getElementById("heartToggleBtn");
+    const progressBar = document.getElementById("progressBar");
+    const audioSeek = document.getElementById("audioSeek");
+    const currentTimeEl = document.getElementById("currentTime");
+    const totalTimeEl = document.getElementById("totalTime");
 
     // Kiểm tra xem HTML đã có chưa, nếu chưa có thì không chạy
     if (!playerContainer || !audio) {
@@ -1358,15 +1373,26 @@ document.addEventListener("DOMContentLoaded", function() {
     let currentTrackIndex = 0;
     let isPlaying = false;
     let isLooping = true; // Mặc định bật loop
+    let isLiked = false;
+    let hasAutoPlayed = false;
+
+    if (loopToggleBtn) {
+        loopToggleBtn.classList.add("is-on");
+    }
+
+    audio.autoplay = true;
 
     // Hàm load bài hát
     function loadTrack(index) {
         try {
             if (index < 0 || index >= playlist.length) index = 0;
             currentTrackIndex = index;
-            
+
             // Cập nhật tên bài hát ngay lập tức
             trackNameElement.textContent = playlist[currentTrackIndex].name;
+            if (trackSubtitleElement) {
+                trackSubtitleElement.textContent = "Duc Tien Radio";
+            }
             
             // Cập nhật source
             audio.src = playlist[currentTrackIndex].src;
@@ -1380,6 +1406,23 @@ document.addEventListener("DOMContentLoaded", function() {
         }
     }
 
+    function formatTime(time) {
+        if (!time || isNaN(time)) return "0:00";
+        const minutes = Math.floor(time / 60);
+        const seconds = Math.floor(time % 60)
+            .toString()
+            .padStart(2, "0");
+        return `${minutes}:${seconds}`;
+    }
+
+    function syncProgress() {
+        if (!audio.duration) return;
+        const progress = (audio.currentTime / audio.duration) * 100;
+        if (progressBar) progressBar.style.width = `${progress}%`;
+        if (audioSeek) audioSeek.value = progress;
+        if (currentTimeEl) currentTimeEl.textContent = formatTime(audio.currentTime);
+    }
+
     function playTrack() {
         // Play trả về Promise, cần catch lỗi nếu trình duyệt chặn auto-play
         var playPromise = audio.play();
@@ -1388,6 +1431,7 @@ document.addEventListener("DOMContentLoaded", function() {
                 isPlaying = true;
                 playPauseBtn.innerHTML = '<i class="fa-solid fa-pause"></i>';
                 // Xoay ảnh đĩa nhạc nếu có (optional)
+                hasAutoPlayed = true;
             })
             .catch(error => {
                 console.log("Trình duyệt chặn phát tự động:", error);
@@ -1442,59 +1486,68 @@ document.addEventListener("DOMContentLoaded", function() {
     loopToggleBtn.addEventListener("click", () => {
         isLooping = !isLooping;
         loopToggleBtn.classList.toggle("active", isLooping);
+        loopToggleBtn.classList.toggle("is-on", isLooping);
     });
 
-    // --- KÉO THẢ (DRAG) ---
-    let isDragging = false;
-    let startX, startY, initialLeft, initialTop;
+    // Nút yêu thích
+    if (heartToggleBtn) {
+        heartToggleBtn.addEventListener("click", () => {
+            isLiked = !isLiked;
+            heartToggleBtn.classList.toggle("is-on", isLiked);
+        });
+    }
 
-    // Chỉ cho phép kéo ở vùng trống của container, không phải nút bấm
-    playerContainer.addEventListener('mousedown', (e) => {
-        if(e.target.closest('button')) return; // Bỏ qua nếu click vào nút
-        isDragging = true;
-        startX = e.clientX;
-        startY = e.clientY;
-        initialLeft = playerContainer.offsetLeft;
-        initialTop = playerContainer.offsetTop;
-        playerContainer.style.cursor = "grabbing";
-    });
-
-    // Touch event cho mobile
-    playerContainer.addEventListener('touchstart', (e) => {
-        if(e.target.closest('button')) return;
-        isDragging = true;
-        const touch = e.touches[0];
-        startX = touch.clientX;
-        startY = touch.clientY;
-        initialLeft = playerContainer.offsetLeft;
-        initialTop = playerContainer.offsetTop;
-    }, {passive: false});
-
-    const onMove = (clientX, clientY) => {
-        if (!isDragging) return;
-        const deltaX = clientX - startX;
-        const deltaY = clientY - startY;
-        playerContainer.style.left = `${initialLeft + deltaX}px`;
-        playerContainer.style.top = `${initialTop + deltaY}px`;
-        playerContainer.style.bottom = "auto"; 
-        playerContainer.style.right = "auto";
-    };
-
-    window.addEventListener('mousemove', (e) => onMove(e.clientX, e.clientY));
-    window.addEventListener('touchmove', (e) => {
-        if(isDragging) e.preventDefault(); // Chặn cuộn trang khi đang kéo player
-        const touch = e.touches[0];
-        onMove(touch.clientX, touch.clientY);
-    }, {passive: false});
-
-    const onEnd = () => {
-        isDragging = false;
-        playerContainer.style.cursor = "grab";
-    };
-
-    window.addEventListener('mouseup', onEnd);
-    window.addEventListener('touchend', onEnd);
+    if (audioToggle) {
+        audioToggle.addEventListener('click', () => {
+            const target = audioDock || playerContainer;
+            if (target) {
+                target.classList.toggle('is-collapsed');
+            }
+        });
+    }
 
     // KHỞI TẠO LẦN ĐẦU
     loadTrack(currentTrackIndex);
+
+    audio.addEventListener('canplay', () => {
+        if (!hasAutoPlayed) {
+            playTrack();
+        }
+    }, { once: true });
+
+    // Nỗ lực autoplay bổ sung sau khi metadata sẵn sàng
+    audio.addEventListener('loadeddata', () => {
+        if (!hasAutoPlayed) {
+            setTimeout(() => {
+                if (!hasAutoPlayed) playTrack();
+            }, 150);
+        }
+    });
+
+    audio.addEventListener('loadedmetadata', () => {
+        if (totalTimeEl) totalTimeEl.textContent = formatTime(audio.duration);
+        syncProgress();
+    });
+
+    audio.addEventListener('timeupdate', syncProgress);
+
+    if (audioSeek) {
+        audioSeek.addEventListener('input', (event) => {
+            if (!audio.duration) return;
+            const percent = parseFloat(event.target.value) || 0;
+            const seekTo = (percent / 100) * audio.duration;
+            audio.currentTime = seekTo;
+            syncProgress();
+        });
+    }
+
+    const interactionEvents = ["click", "touchstart", "keydown"];
+    const tryAutoplayOnInteraction = () => {
+        if (!hasAutoPlayed) {
+            playTrack();
+        }
+        interactionEvents.forEach((evt) => document.removeEventListener(evt, tryAutoplayOnInteraction));
+    };
+
+    interactionEvents.forEach((evt) => document.addEventListener(evt, tryAutoplayOnInteraction, { once: true }));
 });

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,7 +9,12 @@ document.addEventListener("DOMContentLoaded", () => {
       .on("enter", function () {
         var progressBar = $(".progress-bar");
         progressBar.each(function () {
-          $(this).css({ width: $(this).attr("aria-valuenow") + "%", "z-index": "2", });
+          const targetWidth = $(this).attr("aria-valuenow") + "%";
+          $(this).css({ width: "0%", "--progress-width": targetWidth, "z-index": "2" });
+          const label = $(this).find(".progress__level");
+          if (label.length) {
+            label.text("0%");
+          }
         });
       });
     });
@@ -83,6 +88,17 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     initCountUp(".profile__info");
 
+    const animatePercentLabel = (label, target, duration = 2000) => {
+      let start = null;
+      const animate = (timestamp) => {
+        if (!start) start = timestamp;
+        const progress = Math.min((timestamp - start) / duration, 1);
+        label.textContent = `${Math.round(progress * target)}%`;
+        if (progress < 1) requestAnimationFrame(animate);
+      };
+      requestAnimationFrame(animate);
+    };
+
     // 2. Skills animation
     const initSkills = () => {
       const skillsSection = document.getElementById("skills");
@@ -91,7 +107,15 @@ document.addEventListener("DOMContentLoaded", () => {
             if (entry.isIntersecting) {
               const progressBars = entry.target.querySelectorAll(".progress-bar");
               progressBars.forEach((progressBar) => {
+                const target = parseInt(progressBar.getAttribute("aria-valuenow")) || parseInt(progressBar.style.getPropertyValue("--progress-width")) || 0;
+                progressBar.style.setProperty("--progress-width", `${target}%`);
+                progressBar.style.width = "0%";
                 progressBar.style.animation = "progressAnimation 3s ease-in-out forwards";
+                const label = progressBar.querySelector(".progress__level");
+                if (label) {
+                  label.textContent = "0%";
+                  animatePercentLabel(label, target, 2000);
+                }
               });
               observer.disconnect();
             }

--- a/index.html
+++ b/index.html
@@ -952,21 +952,57 @@
     </section>
 
     <!--=============== AUDIO ===============-->
-<div class="audio-player-container" id="audioPlayerContainer">
-      <audio id="mainAudio"></audio>
-      <div class="audio-player">
-        <div class="audio-player__info">
-          <p class="audio-player__track-name" id="trackName">Đang tải...</p>
-        </div>
-        <div class="audio-player__controls">
-          <button id="prevBtn" class="audio-player__btn" aria-label="Previous track"><i class="fa-solid fa-backward-step"></i></button>
-          <button id="playPauseBtn" class="audio-player__btn audio-player__btn--play" aria-label="Play/Pause"><i class="fa-solid fa-play"></i></button>
-          <button id="nextBtn" class="audio-player__btn" aria-label="Next track"><i class="fa-solid fa-forward-step"></i></button>
-        </div>
-        <div class="audio-player__settings">
-          <button id="loopToggleBtn" class="audio-player__btn audio-player__btn--loop active" aria-label="Toggle loop"><i class="fa-solid fa-repeat"></i></button>
+    <div class="audio-dock" id="audioDock">
+      <div class="audio-player-container" id="audioPlayerContainer">
+        <audio id="mainAudio"></audio>
+        <div class="audio-player">
+          <div class="audio-player__top">
+            <span class="audio-chip">
+              <span class="audio-chip__dot"></span>
+              Now Playing
+            </span>
+            <span class="audio-icon-badge" aria-hidden="true"><i class="fa-solid fa-headphones"></i></span>
+          </div>
+
+          <div class="audio-player__meta">
+            <div class="audio-cover">
+              <div class="audio-cover__art">
+                <span class="audio-cover__glow"></span>
+                <i class="fa-solid fa-music"></i>
+              </div>
+            </div>
+            <div class="audio-track">
+              <p class="audio-track__title" id="trackName">Đang tải...</p>
+              <p class="audio-track__subtitle" id="trackSubtitle">Duc Tien Radio</p>
+            </div>
+          </div>
+
+          <div class="audio-progress">
+            <div class="audio-progress__rail">
+              <div class="audio-progress__bar" id="progressBar"></div>
+            </div>
+            <input type="range" id="audioSeek" min="0" max="100" value="0" step="0.1" aria-label="Tua thời gian bài hát" />
+            <div class="audio-times">
+              <span class="audio-time" id="currentTime">0:00</span>
+              <span class="audio-time" id="totalTime">0:00</span>
+            </div>
+          </div>
+
+          <div class="audio-player__controls">
+            <button id="loopToggleBtn" class="audio-player__btn audio-player__btn--ghost active" aria-label="Bật tắt lặp"><i class="fa-solid fa-repeat"></i></button>
+            <button id="prevBtn" class="audio-player__btn" aria-label="Bài trước"><i class="fa-solid fa-backward-step"></i></button>
+            <button id="playPauseBtn" class="audio-player__btn audio-player__btn--primary" aria-label="Phát/Tạm dừng"><i class="fa-solid fa-play"></i></button>
+            <button id="nextBtn" class="audio-player__btn" aria-label="Bài tiếp"><i class="fa-solid fa-forward-step"></i></button>
+            <button id="heartToggleBtn" class="audio-player__btn audio-player__btn--ghost" aria-label="Cảm xúc"><i class="fa-solid fa-heart"></i></button>
+          </div>
         </div>
       </div>
+
+      <button class="audio-toggle" id="audioToggle" aria-label="Đóng/mở trình phát">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M9.32 4.22c-.8-.58-1.9 0-1.9.97v13.62c0 .97 1.1 1.55 1.9.97l9.44-6.81c.67-.48.67-1.46 0-1.94L9.32 4.22Z"></path>
+        </svg>
+      </button>
     </div>
       
     <!--=============== FOOTER ===============-->
@@ -993,6 +1029,6 @@
     <script src="/assets/js/imagesloaded.pkgd.min.js"></script>
 
     <!--============== MAIN JS ==============-->
-    <script src="/assets/js/main.js"></script>
+    <script src="/assets/js/main.js" defer></script>
   
 </body></html>

--- a/index.html
+++ b/index.html
@@ -1000,7 +1000,7 @@
 
       <button class="audio-toggle" id="audioToggle" aria-label="Đóng/mở trình phát">
         <svg viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M9.32 4.22c-.8-.58-1.9 0-1.9.97v13.62c0 .97 1.1 1.55 1.9.97l9.44-6.81c.67-.48.67-1.46 0-1.94L9.32 4.22Z"></path>
+          <path d="M9.1 4.4c-.7-.5-1.6 0-1.6.9v13.4c0 .9.9 1.4 1.6.9l8.9-6.7c.6-.5.6-1.4 0-1.9L9.1 4.4Z"></path>
         </svg>
       </button>
     </div>


### PR DESCRIPTION
## Summary
- separate the audio player into a compact dock with an external handle and refreshed gradients that suit both themes
- realign the progress rail/knob and collapse motion so the panel fully hides while leaving a smooth toggle handle
- add theme-independent active colors for loop (green) and heart (pink) controls

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6936d8fca2008328a34dc77ef2597004)